### PR TITLE
Update pkgin Path array for SmartOS Global Zones

### DIFF
--- a/plugins/modules/pkgin.py
+++ b/plugins/modules/pkgin.py
@@ -361,7 +361,7 @@ def main():
         supports_check_mode=True)
 
     global PKGIN_PATH
-    PKGIN_PATH = module.get_bin_path('pkgin', True, ['/opt/local/bin'])
+    PKGIN_PATH = module.get_bin_path('pkgin', True, ['/opt/local/bin','/opt/tools/bin'])
 
     module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')
 


### PR DESCRIPTION
SmartOS Global Zone installs pkgin apps at:

/opt/tools/bin/pkgin

This untested mod adds that as a possible executable location.

##### SUMMARY
SmartOS Global zone mounts the pkgin apps in a unique directory to avoid issues.

This fix adds that as a path for the pkgin utility to use when using ansible.

Error without the change:

global | FAILED! => {
    "changed": false,
    "msg": "Failed to find required executable \"pkgin\" in paths: /usr/ccs/bin:/usr/bin:/bin:/usr/sbin:/sbin"

Special SmartOS note:
SmartOS is unique in that it rewrites everything in the /etc folder except the /ssh/ folder every reboot, so it's not a case where adding /opt/tools/bin to the path will fix the error.